### PR TITLE
EBNT-145 fix random failure of s3 tests

### DIFF
--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -5,7 +5,7 @@ sqlalchemy==1.3.10
 tensorflow==1.14.0
 catboost==0.19.1
 flasgger==0.9.3
-boto3==1.9.252
+boto3==1.10.28
 imageio==2.6.1
 responses==0.10.6
 psutil==5.6.3

--- a/tests/ext/s3/conftest.py
+++ b/tests/ext/s3/conftest.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import pytest
 from everett.manager import config_override
 from testcontainers.core.container import DockerContainer
@@ -32,6 +34,7 @@ def s3server():
             .with_env('SCALITY_ACCESS_KEY_ID', ACCESS_KEY) \
             .with_env('SCALITY_SECRET_ACCESS_KEY', SECRET_KEY) \
             .with_bind_ports(PORT, PORT):
+        sleep(5)  # wait to ensure that s3server has enough time to properly start
         yield
 
 


### PR DESCRIPTION
To resolve "connection closed" problem I first decided to simply update boto3 to latest version. 10 runs on my machine as well as CI yielded no errors. I propose to stay on this solution for now and monitor CI for possible problems.