### PR TITLE
Ebnt 142 warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@
     :alt: Requirements Status
     :target: https://requires.io/github/zyfra/ebonite/requirements/?branch=master
 
-.. |coveralls| image:: https://coveralls.io/repos/zyfra/ebonite/badge.svg?branch=HEAD&service=github
+.. |coveralls| image:: https://coveralls.io/repos/github/zyfra/ebonite/badge.svg?branch=master
     :alt: Coverage Status
     :target: https://coveralls.io/r/zyfra/ebonite
 

--- a/requirements_tests/test_cases.py
+++ b/requirements_tests/test_cases.py
@@ -2,7 +2,7 @@ from ebonite.utils.module import get_object_requirements
 
 
 def test_requirements_analyzer__custom_modules():
-    import tensorflow  # noqa
+    import catboost  # noqa
     from custom_module import MODEL
     reqs = get_object_requirements(MODEL)
 

--- a/src/ebonite/__init__.py
+++ b/src/ebonite/__init__.py
@@ -1,3 +1,13 @@
+# EBNT-142 too many Tensorflow deprecation warnings
+def fix_warnings():  # noqa
+    import logging  # noqa
+    import warnings  # noqa
+    logging.getLogger("tensorflow").setLevel(logging.CRITICAL)  # noqa
+    warnings.filterwarnings('ignore', category=FutureWarning)  # noqa
+    warnings.filterwarnings('ignore', category=DeprecationWarning)  # noqa
+fix_warnings()  # noqa
+
+
 from ebonite import config
 from ebonite.client import Ebonite, create_model
 from ebonite.ext.ext_loader import ExtensionLoader, load_extensions

--- a/src/ebonite/__init__.py
+++ b/src/ebonite/__init__.py
@@ -1,13 +1,3 @@
-# EBNT-142 too many Tensorflow deprecation warnings
-def fix_warnings():  # noqa
-    import logging  # noqa
-    import warnings  # noqa
-    logging.getLogger("tensorflow").setLevel(logging.CRITICAL)  # noqa
-    warnings.filterwarnings('ignore', category=FutureWarning)  # noqa
-    warnings.filterwarnings('ignore', category=DeprecationWarning)  # noqa
-fix_warnings()  # noqa
-
-
 from ebonite import config
 from ebonite.client import Ebonite, create_model
 from ebonite.ext.ext_loader import ExtensionLoader, load_extensions

--- a/src/ebonite/ext/tensorflow/__init__.py
+++ b/src/ebonite/ext/tensorflow/__init__.py
@@ -1,3 +1,13 @@
+# EBNT-142 too many Tensorflow deprecation warnings
+def fix_warnings():  # noqa
+    import logging  # noqa
+    import warnings  # noqa
+    logging.getLogger("tensorflow").setLevel(logging.CRITICAL)  # noqa
+    warnings.filterwarnings('ignore', category=FutureWarning)  # noqa
+    warnings.filterwarnings('ignore', category=DeprecationWarning)  # noqa
+fix_warnings()  # noqa
+
+
 from .dataset import FeedDictDatasetType, FeedDictHook
 from .model import TFTensorHook, TFTensorModelWrapper
 

--- a/src/ebonite/runtime/interface/ml_model.py
+++ b/src/ebonite/runtime/interface/ml_model.py
@@ -4,6 +4,7 @@ from typing import List
 from pyjackson import read
 
 from ebonite.build.provider.ml_model import MODEL_BIN_PATH, MODEL_META_PATH
+from ebonite.build.provider.ml_model_multi import MODELS_META_PATH
 from ebonite.core.objects import core
 from ebonite.runtime.interface import Interface, expose
 from ebonite.runtime.interface.base import InterfaceLoader
@@ -56,9 +57,9 @@ class MultiModelLoader(InterfaceLoader):
     """
 
     def load(self) -> Interface:
-        metas = read(MODEL_META_PATH, List[core.Model])
-        for meta in metas:
-            meta.wrapper.load(os.path.join(MODEL_BIN_PATH, meta.name))
+        metas = read(MODELS_META_PATH, List[core.Model])
+        for i, meta in enumerate(metas):
+            meta.wrapper.load(os.path.join(MODEL_BIN_PATH, str(i)))
         ifaces = {
             meta.name: model_interface(meta) for meta in metas
         }

--- a/tests/ext/flask/test_client.py
+++ b/tests/ext/flask/test_client.py
@@ -6,6 +6,7 @@ import responses
 from pandas import DataFrame
 from requests.exceptions import HTTPError
 
+import ebonite
 from ebonite.ext.flask.client import HTTPClient
 
 interface_json = '''
@@ -15,9 +16,9 @@ interface_json = '''
       "args":{"vector":{"columns":["a","b"],"type":"ebonite.ext.pandas.dataset.DataFrameType"}},
       "name":"predict",
       "out_type":{"dtype":"float64","shape":[2],"type":"ebonite.ext.numpy.dataset.NumpyNdarrayDatasetType"}}],
-  "version":"0.2.0"
+  "version":"EBONITE_VERSION"
 }
-'''
+'''.replace('EBONITE_VERSION', ebonite.__version__)
 
 
 @pytest.fixture

--- a/tests/ext/flask/test_client.py
+++ b/tests/ext/flask/test_client.py
@@ -16,9 +16,9 @@ interface_json = '''
       "args":{"vector":{"columns":["a","b"],"type":"ebonite.ext.pandas.dataset.DataFrameType"}},
       "name":"predict",
       "out_type":{"dtype":"float64","shape":[2],"type":"ebonite.ext.numpy.dataset.NumpyNdarrayDatasetType"}}],
-  "version":"EBONITE_VERSION"
+  "version":"%s"
 }
-'''.replace('EBONITE_VERSION', ebonite.__version__)
+''' % ebonite.__version__
 
 
 @pytest.fixture

--- a/tests/utils/test_module_tools.py
+++ b/tests/utils/test_module_tools.py
@@ -19,8 +19,8 @@ def test_check_pypi_module():
     assert check_pypi_module('numpy', '1.17.3')
     assert check_pypi_module('pandas')
 
-    assert not check_pypi_module('my-super-module')
-    assert not check_pypi_module('pandas', '100.200.300')
+    assert not check_pypi_module('my-super-module', warn_on_error=False)
+    assert not check_pypi_module('pandas', '100.200.300', warn_on_error=False)
 
     with pytest.raises(ValueError):
         check_pypi_module('my-super-module', raise_on_error=True)


### PR DESCRIPTION
Eliminated tensorflow warnings. Added more tests for providers/loaders. Fixed bugs in multi-model provider/builder.

NB: PyTorch warnings left in logs but they appear under tox only. When I run pytest directly there is no such warnings. I suspect this is because tox installs ebonite locally in its virtualenv before running tests while direct pytest run uses sources from disk.