### PR TITLE
EBNT-290 clean up and upgrade ebonite dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,7 @@
-docker==4.1.0
-pyyaml==5.1.2
-requests==2.22.0
+docker==4.2.0
+requests==2.23.0
 dill==0.3.1.1
-GitPython==3.0.3
 isort==4.3.21
 pyjackson==0.0.25
 everett==1.0.2
-Jinja2==2.10.1
-# click
-# eg: aspectlib==1.1.1 six>=1.7
+Jinja2==2.11.1

--- a/test.requirements.txt
+++ b/test.requirements.txt
@@ -1,28 +1,24 @@
-pandas==0.25.1
-numpy==1.17.3
-scipy==1.3.3
-scikit-learn==0.22
-sqlalchemy==1.3.10
-psycopg2-binary==2.8.4
+pandas==1.0.3
+numpy==1.18.2
+scipy==1.4.1
+scikit-learn==0.22.2
+sqlalchemy==1.3.16
+psycopg2-binary==2.8.5
 tensorflow==2.0.1
-catboost==0.19.1
-flasgger==0.9.3
+catboost==0.22
+flasgger==0.9.4
 aiohttp==3.6.2
 aiohttp-swagger==1.0.14
-pyyaml==5.1.2
-boto3==1.10.28
-imageio==2.6.1
-# PNG plugin is broken in Pillow 7.1.x
-Pillow==7.0.0
-responses==0.10.6
-psutil==5.6.6
-testcontainers==2.5
+pyyaml==5.3.1
+boto3==1.12.39
+imageio==2.8.0
+responses==0.10.12
+psutil==5.7.0
+testcontainers==2.6.0
 pytest==5.2.2
-xgboost==0.90
-lightgbm==2.3.0
+xgboost==1.0.2
+lightgbm==2.3.1
 
-torch==1.3.1+cpu ; sys_platform != "darwin"
-torchvision==0.4.2+cpu ; sys_platform != "darwin"
+torch==1.4.0+cpu ; sys_platform != "darwin"
 
-torch==1.3.1 ; sys_platform == "darwin"
-torchvision==0.4.2 ; sys_platform == "darwin"
+torch==1.4.0 ; sys_platform == "darwin"

--- a/tests/build/builder/test_base.py
+++ b/tests/build/builder/test_base.py
@@ -169,7 +169,7 @@ def test_python_builder__distr_runnable(tmpdir, python_builder_mock: PythonBuild
 
 
 @pytest.mark.parametrize(("python_builder", "server_reqs"), [
-    ("python_builder_sync", {'flasgger==0.9.3'}),
+    ("python_builder_sync", {'flasgger==0.9.4'}),
     ("python_builder_async", {'aiohttp_swagger'})
 ])
 def test_python_builder_flask_distr_runnable(tmpdir, python_builder, pandas_data, server_reqs, request):
@@ -178,7 +178,7 @@ def test_python_builder_flask_distr_runnable(tmpdir, python_builder, pandas_data
 
     from setup import setup_args
     _check_requirements(tmpdir, {*setup_args['install_requires'], *server_reqs,
-                                 'pandas==0.25.1', 'scikit-learn==0.22', 'numpy==1.17.3'})  # model reqs
+                                 'pandas==1.0.3', 'scikit-learn==0.22.2', 'numpy==1.18.2'})  # model reqs
 
     # TODO make ModelLoader.load cwd-independent
     server = subprocess.Popen(args, env=env, cwd=tmpdir)

--- a/tests/ext/xgboost/test_model.py
+++ b/tests/ext/xgboost/test_model.py
@@ -29,7 +29,7 @@ def test_wrapper__predict(wrapper, dmatrix_np):
 
 
 def test_wrapper__predict_not_dmatrix(wrapper):
-    data = [1]
+    data = np.asarray([[1]])
     predict = wrapper.call_method('predict', data)
     assert isinstance(predict, np.ndarray)
     assert len(predict) == len(data)


### PR DESCRIPTION
* Upgraded libraries to latest versions
* Eliminated duplicated `pyyaml`
* Eliminated unused `GitPython`
* Eliminated hack for buggy `Pillow` (it was finally fixed)
* Eliminated unused `torchvision`
* New `xgboost` deleted prediction for list. It was deprecated long ago and constantly issued warning in our past builds. I've changed test to use `ndarray`.
* We couldn't upgrade `pytest` as `interface_hook_creator` breaks. Seems like `pytest` internals were changed.
* Python 3.8 requires `Tensorflow` 2.2 which is RC now.
* Non-Docker tests have passed in my local Docker container with Python 3.8.
* Unfortunately `pandas` 0.x has no wheel pre-compiled for Python 3.8. Thus we couldn't use it: its compilations takes 5-10 minutes which would horribly slow down installation in CI and Docker images building in tests. Fortunately `pandas` 1.x seems not to require any changes from our side.

