### PR TITLE
EBNT-289 Better diagnostics for ports conflicts in tests

### DIFF
--- a/tests/build/builder/test_base.py
+++ b/tests/build/builder/test_base.py
@@ -20,6 +20,8 @@ from ebonite.ext.flask.client import HTTPClient
 from ebonite.runtime.interface.ml_model import ModelLoader, MultiModelLoader
 from ebonite.utils.module import get_module_version
 
+from tests.build.conftest import check_ebonite_port_free
+
 # in Python < 3.7 type of patterns is private, from Python 3.7 it becomes `re.Pattern`
 Pattern = type(re.compile(''))
 
@@ -179,6 +181,8 @@ def test_python_builder_flask_distr_runnable(tmpdir, python_builder, pandas_data
     from setup import setup_args
     _check_requirements(tmpdir, {*setup_args['install_requires'], *server_reqs,
                                  'pandas==1.0.3', 'scikit-learn==0.22.2', 'numpy==1.18.2'})  # model reqs
+
+    check_ebonite_port_free()
 
     # TODO make ModelLoader.load cwd-independent
     server = subprocess.Popen(args, env=env, cwd=tmpdir)

--- a/tests/build/builder/test_docker.py
+++ b/tests/build/builder/test_docker.py
@@ -17,7 +17,6 @@ CLEAN = True
 IMAGE_NAME = 'ebonite_test_docker_builder_image'
 
 REGISTRY_PORT = 5000
-REGISTRY_HOST = f'localhost:{REGISTRY_PORT}'
 
 no_docker = pytest.mark.skipif(not has_docker(), reason='docker is unavailable or skipped')
 
@@ -30,9 +29,10 @@ def docker_builder_local_registry():
 
 @pytest.fixture
 def docker_builder_remote_registry():
-    with use_local_installation(), DockerContainer('registry:latest').with_bind_ports(REGISTRY_PORT, REGISTRY_PORT):
+    with use_local_installation(), DockerContainer('registry:latest').with_exposed_ports(REGISTRY_PORT) as container:
+        host = f'localhost:{container.get_exposed_port(REGISTRY_PORT)}'
         yield DockerBuilder(ProviderMock(),
-                            DockerImage(IMAGE_NAME, registry=RemoteDockerRegistry(REGISTRY_HOST)))
+                            DockerImage(IMAGE_NAME, registry=RemoteDockerRegistry(host)))
 
 
 @contextlib.contextmanager

--- a/tests/build/conftest.py
+++ b/tests/build/conftest.py
@@ -1,10 +1,12 @@
 import os
+import socket
 
 import docker.errors
 import pandas as pd
 import pytest
 from ebonite.build.docker import create_docker_client, is_docker_running
 from ebonite.core.objects.core import Model
+from ebonite.runtime.server import HTTPServerConfig
 from sklearn.linear_model import LinearRegression
 
 from tests.client.test_func import func
@@ -52,3 +54,16 @@ def train_model():
 def model():
     model = Model.create(func, "kek", "Test Model")
     return model
+
+
+def check_ebonite_port_free():
+    host, port = HTTPServerConfig.host, HTTPServerConfig.port
+    s = socket.socket()
+    # With this option `bind` will fail only if other process actively listens on port
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind((host, port))
+    except OSError:
+        raise OSError(f'Ebonite services start at port {port} but it\'s used by other process') from None
+    finally:
+        s.close()

--- a/tests/build/test_helpers.py
+++ b/tests/build/test_helpers.py
@@ -42,7 +42,7 @@ def service_name():
 @pytest.mark.docker
 @pytest.mark.skipif(not has_docker(), reason='no docker installed')
 def test_run_docker_img(container_name):
-    run_docker_img(container_name, 'mike0sv/ebaklya', detach=True)
+    run_docker_img(container_name, 'mike0sv/ebaklya', ports_mapping={80: None}, detach=True)
     _assert_docker_container_running(container_name)
 
 

--- a/tests/client/client_common.py
+++ b/tests/client/client_common.py
@@ -6,7 +6,7 @@ from ebonite.client import Ebonite
 from ebonite.core.errors import ExistingModelError
 from ebonite.core.objects.core import Model
 from tests.build.builder.test_docker import has_docker
-from tests.build.conftest import train_model
+from tests.build.conftest import check_ebonite_port_free, train_model
 
 
 def test_get_or_create_task(ebnt: Ebonite):
@@ -124,6 +124,8 @@ def test_push_model_project_contains_two_tasks(ebnt: Ebonite, model: Model):
 @pytest.mark.skipif(not has_docker(), reason='no docker installed')
 def test_build_and_run_instance(ebnt, container_name):
     reg, data = train_model()
+
+    check_ebonite_port_free()
 
     instance = ebnt.create_instance_from_model("Test Model", reg, data, project_name="Test Project",
                                                task_name="Test Task", instance_name=container_name, run_instance=True)


### PR DESCRIPTION
* For third-party containers I used random port allocation provided by Docker
* For Ebonite-managed containers and locally running servers I added checks with clear diagnostics